### PR TITLE
Add multi-language support for posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ Then run the build locally:
 ```
 bundle exec jekyll serve
 ```
+
+# Providing Translations
+
+1. Copy the file in `_posts/` that you wish to translate.
+2. Set `lang` to the desired language code.
+3. Verify that `multiLangId` is the same as the base filename **without** the language code.
+4. Translate the file.

--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -30,6 +30,16 @@ navbar-links:
     - Ubuntu Packages: "https://launchpad.net/~bitcoin-abc/+archive/ubuntu/ppa"
   Contributing: "https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/CONTRIBUTING.md"
 
+supported-languages:
+  en: "English"
+  es: "Español"
+  fr: "Français"
+  jp: "日本語"
+  nl: "Nederlands"
+  pt: "Português"
+  zh_simple: "简体中文"
+  zh_traditional: "繁体中文"
+
 # Image to show in the navigation bar - image must be a square (width = height)
 # Remove this parameter if you don't want an image in the navbar
 #avatar: "/img/avatar-icon.png"

--- a/_config-prod.yml
+++ b/_config-prod.yml
@@ -30,6 +30,16 @@ navbar-links:
     - Ubuntu Packages: "https://launchpad.net/~bitcoin-abc/+archive/ubuntu/ppa"
   Contributing: "https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/CONTRIBUTING.md"
 
+supported-languages:
+  en: "English"
+  es: "Español"
+  fr: "Français"
+  jp: "日本語"
+  nl: "Nederlands"
+  pt: "Português"
+  zh_simple: "简体中文"
+  zh_traditional: "繁体中文"
+
 # Image to show in the navigation bar - image must be a square (width = height)
 # Remove this parameter if you don't want an image in the navbar
 #avatar: "/img/avatar-icon.png"

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,16 @@ navbar-links:
     - Ubuntu Packages: "https://launchpad.net/~bitcoin-abc/+archive/ubuntu/ppa"
   Contributing: "https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/CONTRIBUTING.md"
 
+supported-languages:
+  en: "English"
+  es: "Español"
+  fr: "Français"
+  jp: "日本語"
+  nl: "Nederlands"
+  pt: "Português"
+  zh_simple: "简体中文"
+  zh_traditional: "繁体中文"
+
 # Image to show in the navigation bar - image must be a square (width = height)
 # Remove this parameter if you don't want an image in the navbar
 #avatar: "/img/avatar-icon.png"

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -16,6 +16,19 @@
 
     <div class="collapse navbar-collapse" id="main-navbar">
       <ul class="nav navbar-nav navbar-right">
+      {% assign multiLangPosts = site.posts | where:"multiLangId", page.multiLangId %}
+      {% if multiLangPosts.size > 1 %}
+        {% assign currentLanguage = site.supported-languages[page.lang] %}
+        <li class="navlinks-container">
+          <a class="navlinks-parent" href="javascript:void(0)">{{ currentLanguage }}</a>
+          <div class="navlinks-children">
+            {% assign multiLangPosts = site.posts | where:"multiLangId", page.multiLangId %}
+            {% for post in multiLangPosts %}
+              <a href="{{ post.url }}">{{ site.supported-languages[post.lang] }}</a>
+            {% endfor %}
+          </div>
+        </li>
+      {% endif %}
       {% for link in site.navbar-links %}
         {% if link[1].first %}
           <li class="navlinks-container">

--- a/_posts/2015-02-28-test-markdown.md
+++ b/_posts/2015-02-28-test-markdown.md
@@ -6,6 +6,8 @@ gh-repo: daattali/beautiful-jekyll
 gh-badge: [star, fork, follow]
 tags: [test]
 published: false
+multiLangId: 2015-02-28-test-markdown
+lang: en
 ---
 
 You can write regular [markdown](http://markdowntutorial.com/) here and Jekyll will automatically convert it to a nice webpage.  I strongly encourage you to [take 5 minutes to learn how to write in markdown](http://markdowntutorial.com/) - it'll teach you how to transform regular text into bold/italics/headings/tables/etc.

--- a/_posts/2017-11-01-DAA.md
+++ b/_posts/2017-11-01-DAA.md
@@ -1,7 +1,9 @@
 ---
 layout: post
 title: Difficulty Adjustment Algorithm Update
-subtitle: Bitcoin ABC has published version 0.16.0 which contains an updated Difficulty Adjustment Algorithm (DAA).  
+subtitle: Bitcoin ABC has published version 0.16.0 which contains an updated Difficulty Adjustment Algorithm (DAA).
+multiLangId: 2017-11-01-DAA
+lang: en
 ---
 
 ## Bitcoin ABC has published version 0.16.0 which contains an updated Difficulty Adjustment Algorithm (DAA). 

--- a/_posts/2017-12-01-dev-plan.md
+++ b/_posts/2017-12-01-dev-plan.md
@@ -1,6 +1,8 @@
 ---
 layout: post
 title: Medium Term Development Plan
+multiLangId: 2017-12-01-dev-plan
+lang: en
 ---
 
 ## Bitcoin ABC - Medium Term Development Plan

--- a/_posts/2018-01-14-CashAddr.md
+++ b/_posts/2018-01-14-CashAddr.md
@@ -2,6 +2,8 @@
 layout: post
 title: CashAddr Addresses Are Here 
 subtitle: Version 0.16.2 Supports the new CashAddr Bitcoin Cash Address Format.
+multiLangId: 2018-01-14-CashAddr
+lang: en
 ---
 ## Bitcoin ABC Releases Software Version 0.16.2 Featuring the new CashAddr Address Format 
 

--- a/_posts/2018-04-01-upgrade.md
+++ b/_posts/2018-04-01-upgrade.md
@@ -2,6 +2,8 @@
 layout: post
 title: May 15th Network Upgrade
 subtitle: Bitcoin Cash is adding opcodes and 32mb blocks
+multiLangId: 2018-04-01-upgrade
+lang: en
 ---
 
 ## What is Happening May 15th?  

--- a/_posts/2018-05-07-incident-report.md
+++ b/_posts/2018-05-07-incident-report.md
@@ -2,6 +2,8 @@
 layout: post
 title: Bitcoin-ABC incident report (26APR2018)
 subtitle: 
+multiLangId: 2018-05-07-incident-report
+lang: en
 ---
 
 This document contains information regarding the response to a critical vulnerability applicable to miners of Bitcoin Cash using Bitcoin-ABC 0.17.0. Appropriate action has been taken to mitigate the impact of this vulnerability. This document is provided for information purposes only.

--- a/_posts/2018-07-05-nov-hardfork-timeline.md
+++ b/_posts/2018-07-05-nov-hardfork-timeline.md
@@ -2,6 +2,8 @@
 layout: post
 title: November Upgrade Timeline
 subtitle: Planning ahead for the upcoming network upgrade
+multiLangId: 2018-07-05-nov-hardfork-timeline
+lang: en
 ---
 
 As the November 15th hardfork upgrade approaches and proposals continue to be discussed, the Bitcoin ABC team would like to set a timeline to ensure a smooth upgrade in November. Using our learnings from the previous fork in May, we want to make sure people are aware of these dates in advance, and more importantly, that the community help us encourage everyone to stick to them.  

--- a/_posts/2018-08-08-nov-code-complete-reminder.md
+++ b/_posts/2018-08-08-nov-code-complete-reminder.md
@@ -2,6 +2,8 @@
 layout: post
 title: November hardfork changes to be completed by August 15th
 subtitle: Only one week left before the code-complete date
+multiLangId: 2018-08-08-nov-code-complete-reminder
+lang: en
 ---
 
 Keeping inline with our proposed [November Upgrade Timeline](https://www.bitcoinabc.org/2018-07-05-nov-hardfork-timeline/), Bitcoin ABC has been striving to have consensus-related changes be in a code-complete state by August 15th. This is both a reminder to those contributing code to Bitcoin ABC and a status update to the community.  Once all changes are in on August 15th, we will be cutting a release for 0.18.0 and begin testing on testnet.

--- a/_posts/2018-08-20-announcing-bitcoin-abc-0-18-0.md
+++ b/_posts/2018-08-20-announcing-bitcoin-abc-0-18-0.md
@@ -2,6 +2,8 @@
 layout: post
 title: Announcing Bitcoin ABC 0.18.0
 subtitle: Be sure to upgrade before November
+multiLangId: 2018-08-20-announcing-bitcoin-abc-0-18-0
+lang: en
 ---
 
 We are pleased to announce that Bitcoin ABC 0.18.0 has been released. You can download it at: 

--- a/announcements.html
+++ b/announcements.html
@@ -4,7 +4,8 @@ use-site-title: true
 ---
 
 <div class="posts-list">
-  {% for post in site.posts %}
+  {% assign english_posts = site.posts | where: "lang", "en" %}
+  {% for post in english_posts %}
   <article class="post-preview">
     <a href="{{ post.url | prepend: site.baseurl }}">
 	  <h2 class="post-title">{{ post.title }}</h2>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,8 @@ use-site-title: true
     <a style="margin-right: 1em;" href="https://github.com/Bitcoin-ABC/bitcoin-abc">Source Code</a>
     <a style="margin-left: 1em;" href="https://download.bitcoinabc.org/">Binaries</a>
   </div>
-  {% assign first_posts = site.posts | slice: 0, site.front_page_posts %}
+  {% assign english_posts = site.posts | where: "lang", "en" %}
+  {% assign first_posts = english_posts | slice: 0, site.front_page_posts %}
   <div class="posts-list">
     {% for post in first_posts %}
     <article class="post-preview">


### PR DESCRIPTION
Considering using this plugin longer-term: https://github.com/Anthony-Gaudino/jekyll-multiple-languages-plugin For now, these changes will allow us to selectively translate posts with minimal changes and without impacting the rest of the site.