### PR TITLE
Exclude build/config files from jekyll build

### DIFF
--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -187,6 +187,9 @@ exclude:
   - LICENSE
   - README.md
   - Vagrantfile
+  - nginx.conf
+  - Makefile
+  - Rakefile
 
 # prose.io config
 prose:

--- a/_config-prod.yml
+++ b/_config-prod.yml
@@ -187,6 +187,9 @@ exclude:
   - LICENSE
   - README.md
   - Vagrantfile
+  - nginx.conf
+  - Makefile
+  - Rakefile
 
 # prose.io config
 prose:

--- a/_config.yml
+++ b/_config.yml
@@ -187,6 +187,9 @@ exclude:
   - LICENSE
   - README.md
   - Vagrantfile
+  - nginx.conf
+  - Makefile
+  - Rakefile
 
 # prose.io config
 prose:


### PR DESCRIPTION
Some configuration and build scripts were accidentally being included in the jekyll build and should be excluded to not leak them on the website.