### PR TITLE
Cleanup nginx.conf redirects and other nits

### DIFF
--- a/_posts/2018-01-14-CashAddr.md
+++ b/_posts/2018-01-14-CashAddr.md
@@ -4,6 +4,7 @@ title: CashAddr Addresses Are Here
 subtitle: Version 0.16.2 Supports the new CashAddr Bitcoin Cash Address Format.
 multiLangId: 2018-01-14-CashAddr
 lang: en
+permalink: cashaddr/
 ---
 ## Bitcoin ABC Releases Software Version 0.16.2 Featuring the new CashAddr Address Format 
 

--- a/_posts/2018-04-01-upgrade.md
+++ b/_posts/2018-04-01-upgrade.md
@@ -4,6 +4,7 @@ title: May 15th Network Upgrade
 subtitle: Bitcoin Cash is adding opcodes and 32mb blocks
 multiLangId: 2018-04-01-upgrade
 lang: en
+permalink: may15hardfork/
 ---
 
 ## What is Happening May 15th?  

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,20 +30,18 @@ map $http_accept_language $lang {
     ~^zh zh-CN;
 }
 
-
-
 server {
     listen       80;
     server_name  bitcoinabc.org;
 
-    if ( $http_host = 'bitcoinabc.org' ){
+    if ($http_host = 'bitcoinabc.org') {
         return 301 https://www.bitcoinabc.org$request_uri;
     }
 
-    if ( $http_x_forwarded_proto = 'http' ) {
+    if ($http_x_forwarded_proto = 'http') {
         return 301 https://$host$request_uri;
     }
-   
+
     root   /usr/share/nginx/html;
 
     location / {

--- a/nginx.conf
+++ b/nginx.conf
@@ -40,14 +40,6 @@ server {
         return 301 https://www.bitcoinabc.org$request_uri;
     }
 
-    if ( $request_uri = '/may15hardfork' ){
-        return 301 https://www.bitcoinabc.org/2018-04-01-upgrade/;
-    }
-
-    if ( $request_uri = '/cashaddr' ){
-        return 301 https://www.bitcoinabc.org/2018-01-14-CashAddr/;
-    }
-
     if ( $http_x_forwarded_proto = 'http' ) {
         return 301 https://$host$request_uri;
     }


### PR DESCRIPTION
Although applying these redirects as 301s may be more technically correct, applying them as Jekyll permalinks is easier to maintain and test locally.