### PR TITLE
Update disclosure policy, add it to the footer, and fix various footer issues on small devices

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,21 +23,17 @@
           </li>
           {%- endfor -%}
         </ul>
-        <div style="text-align:center; margin-top: 1em;">
+        <div class="footer-donation-addr" style="text-align:center; margin-top: 1em;">
           You can help us by making a Bitcoin Cash donation.
           <br>
           <a href="https://blockdozer.com/address/qqeht8vnwag20yv8dvtcrd4ujx09fwxwsqqqw93w88" style="font-weight:bold;">bitcoincash:qqeht8vnwag20yv8dvtcrd4ujx09fwxwsqqqw93w88</a>
-        <div>
+        </div>
         <div style="text-align:center; margin-top: 1em;">
-          Support is welcome as long as you understand
-          <br>
-          that any funds sent are considered a donation
-          <br>
-          to be used at the sole discretion of Bitcoin ABC.
+          Support is welcome as long as you understand that any funds sent are considered a donation to be used at the sole discretion of Bitcoin ABC.
         </div>
         <div style="text-align:center; margin-top: 1em;">
           <p class="copyright text-muted">
-            Copyright 2017-2019 {{ site.author.name }}           
+            Copyright 2017-2019 {{ site.author.name }}
             {% if site.matomo %}
             {% if site.matomo.opt-out %}
             &nbsp;&bull;&nbsp;

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -32,6 +32,9 @@
           Support is welcome as long as you understand that any funds sent are considered a donation to be used at the sole discretion of Bitcoin ABC.
         </div>
         <div style="text-align:center; margin-top: 1em;">
+          Found a bug? See our <a href="/2018-11-08-disclosure-policy" style="font-weight: bold;">disclosure policy</a>.
+        </div>
+        <div style="text-align:center; margin-top: 1em;">
           <p class="copyright text-muted">
             Copyright 2017-2019 {{ site.author.name }}
             {% if site.matomo %}

--- a/_posts/2018-11-08-disclosure-policy.md
+++ b/_posts/2018-11-08-disclosure-policy.md
@@ -65,13 +65,6 @@ Bitcoin ABC Lead Developer
 629D7E5DDDA0512BD5860F2C5D7922BBD649C4A7
 </div>
 
-#### Shammah Chancellor
-<div>
-Bitcoin ABC Developer
-<div class="email-obfuscation"><span>disclo</span><span>###</span><span>sure</span><span>###</span><span>@</span><span>###</span><span>shablag</span><span>###</span><span>.com</span><span>###</span></div>
-7A55A44F3A3239827C8A594E7D3958C44427674A
-</div>
-
 #### Jason B. Cox
 <div>
 Bitcoin ABC Developer

--- a/css/main.css
+++ b/css/main.css
@@ -772,3 +772,17 @@ td.gutter {
   display: none;
 }
 
+.footer-donation-addr a {
+  font-size: 0.8vw
+}
+@media only screen and (max-width: 1400px) {
+  .footer-donation-addr a {
+    font-size: 1.7vw
+  }
+}
+@media only screen and (max-width: 600px) {
+  .footer-donation-addr a {
+    font-size: 2.9vw
+  }
+}
+


### PR DESCRIPTION
In order to free up space in the footer, I reduced the support message from 3 to 1-2 lines of text.  In order to do so properly, I needed to fix a bug where font sizing issues caused text overflow in the footer container.