### PR TITLE
Remove stale testnet information

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,6 @@ use-site-title: true
     <br>
     <a style="margin-right: 1em;" href="https://github.com/Bitcoin-ABC/bitcoin-abc">Source Code</a>
     <a style="margin-left: 1em;" href="https://download.bitcoinabc.org/">Binaries</a>
-    <br>
-    Participate in the test network:
-    <br>
-    <a style="margin-right: 1em;" href="https://docs.google.com/spreadsheets/d/1Wg2ciYk7efDFpUD9qIz2Q9-Qp4H8i0Io8ThdDbGdyPU">Testnet Information</a>
   </div>
   {% assign english_posts = site.posts | where: "lang", "en" %}
   {% assign first_posts = english_posts | slice: 0, site.front_page_posts %}


### PR DESCRIPTION
The testnet information was applicable to pre-Nov-2018 Upgrade.

This is no longer relevant, so it should be removed.

Tested on my local machine, and it looks fine.