### PR TITLE
Generate RPC documentation for every release

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,12 @@
+Repository Tools
+---------------------
+
+### [Developer tools](/contrib/devtools) ###
+Specific tools for developers working on this repository.
+Contains the script `github-merge.py` for merging github pull requests securely and signing them using GPG.
+
+### [Verify-Commits](/contrib/verify-commits) ###
+Tool to verify that every merge commit was signed by a developer using the above `github-merge.py` script.
+
+### [RPC documentation generation](/contrib/doc-gen) ###
+Script for generating RPC documentation files from a running Bitcoin Core instance.

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,12 +1,5 @@
 Repository Tools
 ---------------------
 
-### [Developer tools](/contrib/devtools) ###
-Specific tools for developers working on this repository.
-Contains the script `github-merge.py` for merging github pull requests securely and signing them using GPG.
-
-### [Verify-Commits](/contrib/verify-commits) ###
-Tool to verify that every merge commit was signed by a developer using the above `github-merge.py` script.
-
 ### [RPC documentation generation](/contrib/doc-gen) ###
 Script for generating RPC documentation files from a running Bitcoin Core instance.

--- a/contrib/doc-gen/command-template.html
+++ b/contrib/doc-gen/command-template.html
@@ -1,0 +1,8 @@
+---
+name: {{.Name}}
+bchversion: {{.Version}}
+bchgroup: {{.Group}}
+permalink: {{.Permalink}}
+---
+
+{{.Description}}

--- a/contrib/doc-gen/generate.go
+++ b/contrib/doc-gen/generate.go
@@ -54,11 +54,20 @@ func getVersion() string {
 	return v
 }
 
+func getSeparator(str string) string {
+	if strings.Contains(str, "\r\n") {
+		return "\r\n"
+	} else {
+		return "\n"
+	}
+}
+
 func main() {
 	version := getVersion()
 
 	first := run("help")
-	split := strings.Split(first, "\n")
+	sep := getSeparator(first)
+	split := strings.Split(first, sep)
 
 	groups := make([]Group, 0)
 	commands := make([]Command, 0)

--- a/contrib/doc-gen/generate.go
+++ b/contrib/doc-gen/generate.go
@@ -1,0 +1,167 @@
+// This is a golang script, needed for generating the RPC bitcoin documentation
+//
+// What is necessary to run this:
+// (1) install golang
+// (2) install bitcoin abc, set it up to use regtest
+// (3) run bitcoind
+// (4) run this script with `go run generate.go` while being in contrib/doc-gen, and with bitcoin-cli in PATH
+// (5) add the generated files to git
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"text/template"
+)
+
+const BITCOIN_COMMAND = "bitcoin-cli"
+
+type Command struct {
+	Name        string
+	Description string
+}
+
+type Group struct {
+	Index    int
+	Name     string
+	Commands []Command
+}
+
+type CommandData struct {
+	Version     string
+	Name        string
+	Description string
+	Group       string
+	Permalink   string
+}
+
+func getVersion() string {
+	allInfo := run("getnetworkinfo")
+	var f interface{}
+	err := json.Unmarshal([]byte(allInfo), &f)
+	if err != nil {
+		panic("Cannot read network info as JSON")
+	}
+	m := f.(map[string]interface{})
+
+	numv := int(m["version"].(float64))
+	v := fmt.Sprintf("%d.%d.%d", numv/1000000, (numv/10000)%100, (numv/100)%100)
+	return v
+}
+
+func main() {
+	version := getVersion()
+
+	first := run("help")
+	split := strings.Split(first, "\n")
+
+	groups := make([]Group, 0)
+	commands := make([]Command, 0)
+	lastGroupName := ""
+
+	for _, line := range split {
+		if len(line) > 0 {
+			if strings.HasPrefix(line, "== ") {
+				if len(commands) != 0 {
+					g := Group{
+						Name:     lastGroupName,
+						Commands: commands,
+						Index:    len(groups),
+					}
+					groups = append(groups, g)
+					commands = make([]Command, 0)
+				}
+				lastGroupName = strings.ToLower(line[3 : len(line)-3])
+			} else {
+				name := strings.Split(line, " ")[0]
+				desc := run("help", name)
+				comm := Command{
+					Name:        name,
+					Description: desc,
+				}
+				commands = append(commands, comm)
+			}
+		}
+	}
+
+	g := Group{
+		Name:     lastGroupName,
+		Commands: commands,
+		Index:    len(groups),
+	}
+	groups = append(groups, g)
+
+	tmpl := template.Must(template.ParseFiles("command-template.html"))
+
+	for _, group := range groups {
+		groupname := group.Name
+		dirname := fmt.Sprintf("../../_doc/en/%s/rpc/%s/", version, groupname)
+		err := os.MkdirAll(dirname, 0777)
+		if err != nil {
+			log.Fatalf("Cannot make directory %s: %s", dirname, err.Error())
+		}
+		for _, command := range group.Commands {
+			name := command.Name
+			address := fmt.Sprintf("%s%s.html", dirname, name)
+			permalink := fmt.Sprintf("en/doc/%s/rpc/%s/%s/", version, groupname, name)
+			err = tmpl.Execute(open(address), CommandData{
+				Version:     version,
+				Name:        name,
+				Description: command.Description,
+				Group:       groupname,
+				Permalink:   permalink,
+			})
+			if err != nil {
+				log.Fatalf("Cannot make command file %s: %s", name, err.Error())
+			}
+		}
+		address := fmt.Sprintf("../../_doc/en/%s/rpc/index.html", version)
+		permalink := fmt.Sprintf("en/doc/%s/rpc/", version)
+		err = tmpl.Execute(open(address), CommandData{
+			Version:     version,
+			Name:        "rpcindex",
+			Description: "",
+			Group:       "index",
+			Permalink:   permalink,
+		})
+		if err != nil {
+			log.Fatalf("Cannot make index file: %s", err.Error())
+		}
+
+		address = fmt.Sprintf("../../_doc/en/%s/index.html", version)
+		permalink = fmt.Sprintf("en/doc/%s/", version)
+		err = tmpl.Execute(open(address), CommandData{
+			Version:     version,
+			Name:        "index",
+			Description: "",
+			Group:       "index",
+			Permalink:   permalink,
+		})
+		if err != nil {
+			log.Fatalf("Cannot make index file: %s", err.Error())
+		}
+	}
+}
+
+func open(path string) io.Writer {
+	f, err := os.Create(path)
+	// not closing, program will close sooner
+	if err != nil {
+		log.Fatalf("Cannot open file %s: %s", path, err.Error())
+	}
+	return f
+}
+
+func run(args ...string) string {
+	out, err := exec.Command(BITCOIN_COMMAND, args...).CombinedOutput()
+	if err != nil {
+		log.Fatalf("Cannot run bitcoin-cli: %s, is bitcoind running?", err.Error())
+	}
+
+	return string(out)
+}


### PR DESCRIPTION
This is a script taken from the bitcoincore.org repo adjusted to BCH

https://github.com/bitcoin-core/bitcoincore.org/tree/master/contrib

The script generates a _doc folder with all the RPC functions for every node version and the help information for each of them. 

https://bitcoincore.org/en/doc/

The only part missing is to adjust these generated files to the bitcoinabc.org website. The best would be to add it to the nav menu. I'm not familiarized with Jekyll. so guidance or help on that regard would be very appreciated.
