### PR TITLE
Update disclosure policy link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -32,7 +32,7 @@
           Support is welcome as long as you understand that any funds sent are considered a donation to be used at the sole discretion of Bitcoin ABC.
         </div>
         <div style="text-align:center; margin-top: 1em;">
-          Found a bug? See our <a href="/2018-11-08-disclosure-policy" style="font-weight: bold;">disclosure policy</a>.
+          Found a bug? See our <a href="https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/DISCLOSURE_POLICY.md" style="font-weight: bold;">disclosure policy</a>.
         </div>
         <div style="text-align:center; margin-top: 1em;">
           <p class="copyright text-muted">


### PR DESCRIPTION
The document linked is superseded by a new version.
Linking to the Github markdown should keep the link always
pointing at the up-to-date version.