### PR TITLE
Added docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2.4'
+services:
+  bitcoin-abc-org:
+    build: .
+    image: bitcoin-abc-org:latest
+    ports:
+      - '8080:80'
+    volumes:
+      - /usr/share/nginx/html/


### PR DESCRIPTION
This allows us to easily manage deployments using docker-compose. Assuming you have docker-compose installed, you can test it locally with `docker-compose up` and hitting `localhost:8080`.