### PR TITLE
Point binaries to latest

### DIFF
--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -18,9 +18,10 @@ navbar-links:
   Latest Roadmap: "https://www.bitcoincash.org/roadmap.html"
   Announcements: "announcements/"
   Download:
-    - Binaries: "https://download.bitcoinabc.org/"
+    - Binaries: "https://download.bitcoinabc.org/latest/"
     - Source Code: "https://github.com/Bitcoin-ABC/bitcoin-abc"
     - Ubuntu Packages: "https://launchpad.net/~bitcoin-abc/+archive/ubuntu/ppa"
+    - Archived Binaries: "https://download.bitcoinabc.org/"
   Contributing: "https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/CONTRIBUTING.md"
 
 supported-languages:

--- a/_config-prod.yml
+++ b/_config-prod.yml
@@ -18,9 +18,10 @@ navbar-links:
   Latest Roadmap: "https://www.bitcoincash.org/roadmap.html"
   Announcements: "announcements/"
   Download:
-    - Binaries: "https://download.bitcoinabc.org/"
+    - Binaries: "https://download.bitcoinabc.org/latest/"
     - Source Code: "https://github.com/Bitcoin-ABC/bitcoin-abc"
     - Ubuntu Packages: "https://launchpad.net/~bitcoin-abc/+archive/ubuntu/ppa"
+    - Archived Binaries: "https://download.bitcoinabc.org/"
   Contributing: "https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/CONTRIBUTING.md"
 
 supported-languages:

--- a/_config.yml
+++ b/_config.yml
@@ -18,9 +18,10 @@ navbar-links:
   Latest Roadmap: "https://www.bitcoincash.org/roadmap.html"
   Announcements: "announcements/"
   Download:
-    - Binaries: "https://download.bitcoinabc.org/"
+    - Binaries: "https://download.bitcoinabc.org/latest/"
     - Source Code: "https://github.com/Bitcoin-ABC/bitcoin-abc"
     - Ubuntu Packages: "https://launchpad.net/~bitcoin-abc/+archive/ubuntu/ppa"
+    - Archived Binaries: "https://download.bitcoinabc.org/"
   Contributing: "https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/CONTRIBUTING.md"
 
 supported-languages:

--- a/index.html
+++ b/index.html
@@ -21,10 +21,10 @@ use-site-title: true
     The release below contains <a href="/2020-02-18-bitcoin-abc-0.21.0/">protocol upgrades</a> scheduled to activate on May 15th, 2020.
     Update early to keep your node in sync with the Bitcoin Cash network.
     <br><br>
-    <span style="font-weight: bold">Install the latest version (0.21.5):</span>
+    <span style="font-weight: bold">Install the latest version:</span>
     <br>
     <a style="margin-right: 1em;" href="https://github.com/Bitcoin-ABC/bitcoin-abc">Source Code</a>
-    <a style="margin-left: 1em;" href="https://download.bitcoinabc.org/">Binaries</a>
+    <a style="margin-left: 1em;" href="https://download.bitcoinabc.org/latest/">Binaries</a>
     <br>
     <span style="font-weight: bold">Packages:</span>
     <br>


### PR DESCRIPTION
https://download.bitcoinabc.org/latest/ is now available, so let's use it.