### PR TITLE
update deprecated link to cashaddress spec

### DIFF
--- a/_posts/2018-01-14-CashAddr.md
+++ b/_posts/2018-01-14-CashAddr.md
@@ -83,4 +83,4 @@ No.
 
 **Is there an official CashAddr specification for developers?**
 
-Yes, [here.](https://github.com/bitcoincashorg/spec/blob/master/cashaddr.md)
+Yes, [here.](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md)


### PR DESCRIPTION
the page https://www.bitcoinabc.org/cashaddr/ still links to the deprecated repository https://github.com/bitcoincashorg/spec/blob/master/cashaddr.md