### PR TITLE
Store releases JSON so the site can be version-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Thumbs.db
 ehthumbs.db
 
 _data/blog-feed.json
+_data/github-releases.json

--- a/index.html
+++ b/index.html
@@ -16,7 +16,8 @@ use-site-title: true
   </div>
   <hr>
   <div id="notice">
-    <span style="font-weight: bold">Install the latest version:</span>
+    {% assign latestVersion = site.data.github-releases[0].name %}
+    <span style="font-weight: bold">Install the latest version ({{ latestVersion }}):</span>
     <br>
     <a style="margin-right: 1em;" href="https://github.com/Bitcoin-ABC/bitcoin-abc">Source Code</a>
     <a style="margin-left: 1em;" href="https://download.bitcoinabc.org/latest/">Binaries</a>

--- a/scripts/fetch_documentation.sh
+++ b/scripts/fetch_documentation.sh
@@ -21,11 +21,12 @@ TOPLEVEL=$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)
 
 # Get the last MAX_RELEASES releases
 RELEASES=$(curl -L -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases?per_page=${MAX_RELEASES})
+echo "${RELEASES}" > "${TOPLEVEL}"/_data/github-releases.json
 
-# Extract releases version number 
+# Extract release version numbers
 RELEASE_VERSIONS=($(echo ${RELEASES} | jq -r .[].name))
 
-# Extract releases version number 
+# Extract release tags
 RELEASE_TAGS=($(echo ${RELEASES} | jq -r .[].tag_name))
 
 # Create the cache directory as needed. This is where the sources will be


### PR DESCRIPTION
By saving release JSON data to a file, we can access it during the build and allow the site to be version-aware.

This patch provides only a proof-of-concept by introducing the current version onto the homepage. In a future patch, I will leverage this further to build a release page with both latest and recent versions.